### PR TITLE
Deye Micro Inverters 2mppt not working since automatic Update to Logger FW: MW3_SSL_5408_1.0B

### DIFF
--- a/src/main/resources/definitions/deye_2mppt.yaml
+++ b/src/main/resources/definitions/deye_2mppt.yaml
@@ -5,7 +5,7 @@
 
 requests:
   - start: 0x0003
-    end:  0x0080
+    end:  0x007E
     mb_functioncode: 0x03
 
 parameters:


### PR DESCRIPTION
In the Last weeks my three Deye Inverters got a automatic Update to Firmware Version: MW3_SSL_5408_1.0B
My Inverters are: Deye SUN600G3-EU, Deye SUN-M80G3-EU and Deye SUN-M80G4-EU 
SO all with just 2 mppt and all have the same Problem since the Update MW3_SSL_5408_1.0B. In Openhab there is an Error in the logs: 
[ERROR] [arman.internal.SolarmanLoggerHandler] - Unexpected control code in error response frame

Don't know where but I also read somewhere: "Error Modbus Response to short" or something like this.
I dived more into the Problem and found some german threats:

https://www.photovoltaikforum.com/thread/233881-deye-firmware-mw3-ssl-5408-1-0b-kein-logging-mehr-m%C3%B6glich/

and

https://dy-support.org/community/deye-micro-inverter/port-48899-nach-ota-firmwareupdate-gesperrt/

After reading this I set up an Openhab Development Environment to test this advise and it works for all my Inverters. I'm not sure if the bigger Inverters also need this change, I think especially the 4mppt Inverters are very similar and maybe need this patch to.